### PR TITLE
Export type range/0 used by uniform/1

### DIFF
--- a/src/granderl.erl
+++ b/src/granderl.erl
@@ -5,6 +5,9 @@
     uniform/1
 ]).
 
+-type range() :: 1..4294967295.
+-export_type([range/0]).
+
 -compile(no_native).
 -on_load(init/0).
 
@@ -23,8 +26,6 @@ priv_dir() ->
             filename:join(AppPath, "priv");
         Dir -> Dir
     end.
-
--type range() :: 1..4294967295.
 
 -spec uniform(range()) -> range().
 uniform(_N) -> erlang:nif_error(granderl_nif_not_loaded).


### PR DESCRIPTION
The type spec for `uniform/1` uses a type that is not exported, this makes integration in external projects an issue in regards to type checking.

It also doesn't make sense to keep this type private API-wise.